### PR TITLE
V1.2.1

### DIFF
--- a/.idea/.idea.Chatter/.idea/.gitignore
+++ b/.idea/.idea.Chatter/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/modules.xml
+/.idea.Chatter.iml
+/contentModel.xml
+/projectSettingsUpdater.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.idea.Chatter/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/.idea.Chatter/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/.idea.Chatter/.idea/encodings.xml
+++ b/.idea/.idea.Chatter/.idea/encodings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="PROJECT" charset="windows-1252" />
+  </component>
+</project>

--- a/.idea/.idea.Chatter/.idea/indexLayout.xml
+++ b/.idea/.idea.Chatter/.idea/indexLayout.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="UserContentModel">
+    <attachedFolders />
+    <explicitIncludes />
+    <explicitExcludes />
+  </component>
+</project>

--- a/.idea/.idea.Chatter/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/.idea.Chatter/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,7 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="JsonSchemaCompliance" enabled="false" level="WARNING" enabled_by_default="false" />
+    <inspection_tool class="JsonStandardCompliance" enabled="false" level="ERROR" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/.idea.Chatter/.idea/vcs.xml
+++ b/.idea/.idea.Chatter/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/Chatter.UnitTests/Support/LoggerFake.cs
+++ b/Chatter.UnitTests/Support/LoggerFake.cs
@@ -43,6 +43,11 @@ internal class LoggerFake : ILogger
         _lines.Add("[D]: " + string.Format(pattern, args));
     }
 
+    public void Error(string pattern, params object[] args)
+    {
+        _lines.Add("[E]: " + string.Format(pattern, args));
+    }
+
     public void Error(Exception? exception, string pattern, params object[] args)
     {
         _lines.Add("[E]: " + string.Format(pattern, args));

--- a/Chatter/Chatter.cs
+++ b/Chatter/Chatter.cs
@@ -38,7 +38,7 @@ using JetBrains.Annotations;
 namespace Chatter;
 
 /// <summary>
-///     The entry point for this plugin.
+///    The entry point for this plugin.
 /// </summary>
 [UsedImplicitly]
 public sealed partial class Chatter : IDalamudPlugin

--- a/Chatter/Chatter.csproj
+++ b/Chatter/Chatter.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Authors>James Keesey</Authors>
 		<Company></Company>
-		<Version>1.2.0</Version>
+		<Version>1.2.1</Version>
 		<Description>Plugin to save and filter chats.</Description>
 		<Copyright>(C) James Keesey. All rights reserved.</Copyright>
 		<PackageProjectUrl>https://github.com/jlkeesey/Chatter</PackageProjectUrl>

--- a/Chatter/Chatter.json
+++ b/Chatter/Chatter.json
@@ -8,7 +8,7 @@
   "ApplicableVersion": "any",
   "Tags": [
     "chat",
-    "plugin",
+    "Utility",
     "cats"
   ]
 }

--- a/Chatter/ImGuiX/ImGuiWith.cs
+++ b/Chatter/ImGuiX/ImGuiWith.cs
@@ -22,113 +22,20 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 using System;
-using FFXIVClientStructs.FFXIV.Common.Math;
 using ImGuiNET;
 
 namespace Chatter.ImGuiX;
 
 public static class ImGuiWith
 {
-    public static IDisposable Disabled(bool flag)
-    {
-        return new WithDisabledDisposable(flag);
-    }
-
-    public static IDisposable Color(ImGuiCol idx, Vector4 value)
-    {
-        return new WithColorDisposable(idx, value);
-    }
-
-    public static IDisposable Color(ImGuiCol idx, uint value)
-    {
-        return new WithColorDisposable(idx, value);
-    }
-
-    public static IDisposable Style(ImGuiStyleVar styleVar, Vector2 value)
-    {
-        return new WithStyleDisposable(styleVar, value);
-    }
-
-    public static IDisposable Style(ImGuiStyleVar styleVar, float value)
-    {
-        return new WithStyleDisposable(styleVar, value);
-    }
-
     public static IDisposable TextWrapPos(float value)
     {
         return new WithTextWrapPosDisposable(value);
     }
 
-    public static IDisposable Font(ImFontPtr value)
-    {
-        return new WithFontDisposable(value);
-    }
-
     public static IDisposable ItemWidth(float value)
     {
         return new WithItemWidthDisposable(value);
-    }
-
-    public static IDisposable ID(int value)
-    {
-        return new WithIDDisposable(value);
-    }
-
-    public static IDisposable ID(string value)
-    {
-        return new WithIDDisposable(value);
-    }
-
-    private sealed class WithDisabledDisposable : IDisposable
-    {
-        private readonly bool _flag;
-
-        public WithDisabledDisposable(bool flag)
-        {
-            _flag = flag;
-            if (_flag) ImGui.BeginDisabled();
-        }
-
-        public void Dispose()
-        {
-            if (_flag) ImGui.EndDisabled();
-        }
-    }
-
-    private sealed class WithColorDisposable : IDisposable
-    {
-        public WithColorDisposable(ImGuiCol idx, Vector4 value)
-        {
-            ImGui.PushStyleColor(idx, value);
-        }
-
-        public WithColorDisposable(ImGuiCol idx, uint value)
-        {
-            ImGui.PushStyleColor(idx, value);
-        }
-
-        public void Dispose()
-        {
-            ImGui.PopStyleColor();
-        }
-    }
-
-    private sealed class WithStyleDisposable : IDisposable
-    {
-        public WithStyleDisposable(ImGuiStyleVar styleVar, Vector2 value)
-        {
-            ImGui.PushStyleVar(styleVar, value);
-        }
-
-        public WithStyleDisposable(ImGuiStyleVar styleVar, float value)
-        {
-            ImGui.PushStyleVar(styleVar, value);
-        }
-
-        public void Dispose()
-        {
-            ImGui.PopStyleVar();
-        }
     }
 
     private sealed class WithTextWrapPosDisposable : IDisposable
@@ -144,19 +51,6 @@ public static class ImGuiWith
         }
     }
 
-    private sealed class WithFontDisposable : IDisposable
-    {
-        public WithFontDisposable(ImFontPtr value)
-        {
-            ImGui.PushFont(value);
-        }
-
-        public void Dispose()
-        {
-            ImGui.PopFont();
-        }
-    }
-
     private sealed class WithItemWidthDisposable : IDisposable
     {
         public WithItemWidthDisposable(float value)
@@ -167,24 +61,6 @@ public static class ImGuiWith
         public void Dispose()
         {
             ImGui.PopItemWidth();
-        }
-    }
-
-    private sealed class WithIDDisposable : IDisposable
-    {
-        public WithIDDisposable(int value)
-        {
-            ImGui.PushID(value);
-        }
-
-        public WithIDDisposable(string value)
-        {
-            ImGui.PushID(value);
-        }
-
-        public void Dispose()
-        {
-            ImGui.PopID();
         }
     }
 }

--- a/Chatter/Localization/Loc.cs
+++ b/Chatter/Localization/Loc.cs
@@ -23,6 +23,7 @@
 
 using Chatter.System;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Text.Json;
 using static System.String;
@@ -180,5 +181,180 @@ public class Loc
     public string Message(string key)
     {
         return !_messages.TryGetValue(key, out var message) ? $"??[[{key}]]??" : message;
+    }
+
+    /// <summary>
+    ///     Looks up the plural message by key and returns an object that returns the correct string based on the
+    ///     input values.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         The lookup for a message works by looking the most specific set first, then the less specific, then the
+    ///         fallback set. So for a system set to en_US, the search is messages-en-US.json, then messages-en.json, then
+    ///         messages.json. If no message is found then a default message constructed from the key is returned.
+    ///     </para>
+    /// </remarks>
+    /// <param name="key">The key to lookup.</param>
+    /// <returns>The <c>IMessagePlural</c> object.</returns>
+    public IPluralMessage MessagePlural(string key)
+    {
+        if (_messages.TryGetValue(key, out var message)) return new PluralMessage(key, message, this);
+        return new PluralMessageMissing(key);
+    }
+}
+
+/// <summary>
+///     An object that returns the correct message pattern based on a numeric value. The numeric value
+///     is compared to each pattern and if it matches, then that pattern is returned. There is always a
+///     default pattern that matches all values that is returned if no other value is returned.
+/// </summary>
+public interface IPluralMessage
+{
+    /// <summary>
+    ///     Returns the formatted string value based on the input values.
+    /// </summary>
+    /// <param name="arg0">The numeric value used to select the correct pattern.</param>
+    /// <param name="args">Any additional values.</param>
+    /// <returns>A formatted string.</returns>
+    string Format(long arg0, params object[] args);
+}
+
+/// <summary>
+///     Helper to use when there is no plural definition in the message.json file.
+/// </summary>
+internal class PluralMessageMissing : IPluralMessage
+{
+    private readonly string _key;
+
+    internal PluralMessageMissing(string key)
+    {
+        _key = key;
+    }
+
+    public string Format(long arg0, params object[] args)
+    {
+        return $"??[[plural {arg0}: {_key}]]??";
+    }
+}
+
+/// <summary>
+///     Parses the input pattern string and populates values based on the parsed patterns.
+/// </summary>
+internal class PluralMessage : IPluralMessage
+{
+    private readonly SortedList<long, IMessagePattern> _patterns = [];
+
+    internal PluralMessage(string key, string messagePattern, Loc loc)
+    {
+        var patterns = messagePattern.Split(",");
+        foreach (var pattern in patterns)
+        {
+            var parts = pattern.Split("|");
+            if (parts.Length != 2)
+            {
+                Chatter.Logger?.Error($"Invalid plural pattern for {key}: '{pattern}'");
+                _patterns.Add(long.MaxValue, new DefaultMessagePattern(loc.Message(parts[^1])));
+            }
+            else
+            {
+                if (parts[0] == "*")
+                {
+                    _patterns.Add(long.MaxValue, new DefaultMessagePattern(loc.Message(parts[1])));
+                }
+                else
+                {
+                    if (long.TryParse(parts[0], out var result))
+                    {
+                        _patterns.Add(result, new ValueMessagePattern(result, loc.Message(parts[1])));
+                    }
+                    else
+                    {
+                        Chatter.Logger?.Error($"Pattern match value must be a valid integer: '{parts[0]}'");
+                    }
+                }
+            }
+        }
+
+        if (_patterns.GetValueAtIndex(_patterns.Count - 1) is DefaultMessagePattern) return;
+
+        var message = $"Missing default pattern for key {key}";
+        Chatter.Logger?.Error(message);
+        _patterns.Add(long.MaxValue, new DefaultMessagePattern(message));
+    }
+
+    public string Format(long arg0, params object[] args)
+    {
+        foreach (var messagePattern in _patterns)
+        {
+            if (messagePattern.Value.Matches(arg0)) return messagePattern.Value.Format(arg0, args);
+        }
+
+        return "??[[no pattern matched]]??";
+    }
+}
+
+/// <summary>
+///     Interface for a pattern piece.
+/// </summary>
+internal interface IMessagePattern
+{
+    /// <summary>
+    ///     Returns <c>true</c> if the given value matches this pattern.
+    /// </summary>
+    /// <param name="value">The value to test.</param>
+    /// <returns><c>true</c> if the given value matches this pattern.</returns>
+    bool Matches(long value);
+
+    /// <summary>
+    ///     Formats this pattern using the given values. The pattern will be formatted regardless
+    ///     of whether the <c>Match</c> method returns <c>true</c>.
+    /// </summary>
+    /// <param name="arg0">The first parameter (required).</param>
+    /// <param name="args">The optional remaining parameters.</param>
+    /// <returns>The formatted string.</returns>
+    string Format(long arg0, params object[] args);
+}
+
+/// <summary>
+///     Base for handling the formatting of a specific pattern.
+/// </summary>
+/// <param name="pattern">The pattern that will be formatted.</param>
+internal abstract class BaseMessagePattern(string pattern) : IMessagePattern
+{
+    /// <inheritdoc/>
+    public string Format(long arg0, params object[] args)
+    {
+        return string.Format(pattern, [arg0, .. args,]);
+    }
+
+    /// <inheritdoc/>
+    public abstract bool Matches(long value);
+}
+
+/// <summary>
+///     A pattern string that has a single, numeric match value. This will only be used if the
+///     input value is exactly equal to the <c>index</c> value.
+/// </summary>
+/// <param name="index">The specific match value.</param>
+/// <param name="pattern">The pattern string to use.</param>
+internal class ValueMessagePattern(long index, string pattern) : BaseMessagePattern(pattern)
+{
+    /// <inheritdoc/>
+    public override bool Matches(long value)
+    {
+        return value == index;
+    }
+}
+
+/// <summary>
+///     A Default pattern string used when no other value matches.
+/// </summary>
+/// <param name="pattern">The pattern string to use.</param>
+internal class DefaultMessagePattern(string pattern) : BaseMessagePattern(pattern)
+{
+    /// <inheritdoc/>
+    public override bool Matches(long value)
+    {
+        return true;
     }
 }

--- a/Chatter/Localization/Loc.cs
+++ b/Chatter/Localization/Loc.cs
@@ -39,7 +39,10 @@ public class Loc
 {
     private static readonly JsonSerializerOptions SerializeOptions = new()
     {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
     };
 
     private LocalizedMessageList _messages = new();
@@ -53,7 +56,7 @@ public class Loc
         if (IsNullOrWhiteSpace(language))
             throw new ArgumentException("Argument cannot be null, empty, or whitespace", nameof(language));
         if (IsNullOrWhiteSpace(country))
-            throw new ArgumentException("Argument cannot be null, empty, or whitespace", nameof(language));
+            throw new ArgumentException("Argument cannot be null, empty, or whitespace", nameof(country));
         Language = language;
         Country = country;
     }

--- a/Chatter/Localization/messages.json
+++ b/Chatter/Localization/messages.json
@@ -809,6 +809,146 @@
       "key": "Label.EventLength.Help",
       "message": "The legnth of time this event will be active.",
       "description": ""
+    },
+    {
+      "key": "Title.StartEvent",
+      "message": "Start Event",
+      "description": ""
+    },
+    {
+      "key": "Title.StopEvent",
+      "message": "Stop Event",
+      "description": ""
+    },
+    {
+      "key": "Combo.NoInactiveEvents",
+      "message": "(no inactive events)",
+      "description": ""
+    },
+    {
+      "key": "Combo.NoInactiveEvents.Help",
+      "message": "There are no inactive events to start.",
+      "description": ""
+    },
+    {
+      "key": "Label.EventsInactive",
+      "message": "Events",
+      "description": ""
+    },
+    {
+      "key": "Label.EventsInactive.Help",
+      "message": "The list of inactive events to choose from.",
+      "description": ""
+    },
+    {
+      "key": "Combo.NoActiveEvents",
+      "message": "(no active events)",
+      "description": ""
+    },
+    {
+      "key": "Combo.NoActiveEvents.Help",
+      "message": "There are no active events to stop.",
+      "description": ""
+    },
+    {
+      "key": "Label.EventsActive",
+      "message": "Events",
+      "description": ""
+    },
+    {
+      "key": "Label.EventsActive.Help",
+      "message": "The list of active events to choose from.",
+      "description": ""
+    },
+    {
+      "key": "Title.MainWindow",
+      "message": "Chatter",
+      "description": ""
+    },
+    {
+      "key": "Title.ConfigurationWindow",
+      "message": "Chatter Configuration",
+      "description": ""
+    },
+    {
+      "key": "Label.TimeRemaining",
+      "message": "Time remaining {0}",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Days",
+      "message": "1|Format.Period.Days.1,*|Format.Period.Days.0",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Days.0",
+      "message": "{0:D} days, {1:D} hours, {2:D} minutes, and {3:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Days.1",
+      "message": "{0:D} day, {1:D} hours, {2:D} minutes, and {3:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Hours",
+      "message": "1|Format.Period.Hours.1,*|Format.Period.Hours.0",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Hours.0",
+      "message": "{0:D} hours, {1:D} minutes, and {2:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Hours.1",
+      "message": "{0:D} hour, {1:D} minutes, and {2:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Minutes",
+      "message": "1|Format.Period.Minutes.1,*|Format.Period.Minutes.0",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Minutes.0",
+      "message": "{0:D} minutes and {1:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Minutes.1",
+      "message": "{0:D} minute and {1:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Seconds",
+      "message": "1|Format.Period.Seconds.1,*|Format.Period.Seconds.0",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Seconds.0",
+      "message": "{0:D} seconds",
+      "description": ""
+    },
+    {
+      "key": "Format.Period.Seconds.1",
+      "message": "{0:D} second",
+      "description": ""
+    },
+    {
+      "key": "Button.RemoveUser.Help",
+      "message": "Removes the user.",
+      "description": ""
+    },
+    {
+      "key": "Button.DeleteGroup.Help",
+      "message": "Deletes the group.",
+      "description": ""
+    },
+    {
+      "key": "Button.CopyToClipboard.Help",
+      "message": "Copies the directory path to theclipboard and opens the file explorer at the location.",
+      "description": ""
     }
   ]
 }

--- a/Chatter/Localization/messages.json
+++ b/Chatter/Localization/messages.json
@@ -2,953 +2,771 @@
   "messages": [
     {
       "key": "ChatType.Say",
-      "message": "Say",
-      "description": "Label for Say chat type include/exclude checkbox"
+      "message": "Say"
+      /* Label for Say chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Yell",
-      "message": "Yell",
-      "description": "Label for Yell chat type include/exclude checkbox"
+      "message": "Yell"
+      /* Label for Yell chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Shout",
-      "message": "Shout",
-      "description": "Label for Shout chat type include/exclude checkbox"
+      "message": "Shout"
+      /* Label for Shout chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Tell",
-      "message": "Tell",
-      "description": "Label for Tell chat type include/exclude checkbox"
+      "message": "Tell"
+      /* Label for Tell chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Party",
-      "message": "Party",
-      "description": "Label for Party chat type include/exclude checkbox"
+      "message": "Party"
+      /* Label for Party chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.FreeCompany",
-      "message": "FC",
-      "description": "Label for FreeCompany chat type include/exclude checkbox"
+      "message": "FC"
+      /* Label for FreeCompany chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Alliance",
-      "message": "Alliance",
-      "description": "Label for Alliance chat type include/exclude checkbox"
+      "message": "Alliance"
+      /* Label for Alliance chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Emote",
-      "message": "Emote",
-      "description": "Label for Emote chat type include/exclude checkbox"
+      "message": "Emote"
+      /* Label for Emote chat type include/exclude checkbox */
     },
     {
       "key": "ChatType.Say.Help",
-      "message": "When checked /say (/s) messages are included.",
-      "description": ""
+      "message": "When checked /say (/s) messages are included."
     },
     {
       "key": "ChatType.Yell.Help",
-      "message": "When checked /yell (/y) messages are included.",
-      "description": ""
+      "message": "When checked /yell (/y) messages are included."
     },
     {
       "key": "ChatType.Shout.Help",
-      "message": "When checked /shout (/sh) messages are included.",
-      "description": ""
+      "message": "When checked /shout (/sh) messages are included."
     },
     {
       "key": "ChatType.Tell.Help",
-      "message": "When checked /tell (/t) messages are included.",
-      "description": ""
+      "message": "When checked /tell (/t) messages are included."
     },
     {
       "key": "ChatType.Party.Help",
-      "message": "When checked /party (/p) messages are included.",
-      "description": ""
+      "message": "When checked /party (/p) messages are included."
     },
     {
       "key": "ChatType.FreeCompany.Help",
-      "message": "When checked /freecompany (/fc) messages are included.",
-      "description": ""
+      "message": "When checked /freecompany (/fc) messages are included."
     },
     {
       "key": "ChatType.Alliance.Help",
-      "message": "When checked /alliance (/a) messages are included.",
-      "description": ""
+      "message": "When checked /alliance (/a) messages are included."
     },
     {
       "key": "ChatType.Emote.Help",
-      "message": "When checked /emote (/em) messages are included.",
-      "description": ""
+      "message": "When checked /emote (/em) messages are included."
     },
     {
       "key": "ChatType.Ls1",
-      "message": "Ls1",
-      "description": ""
+      "message": "Ls1"
     },
     {
       "key": "ChatType.Ls2",
-      "message": "Ls2",
-      "description": ""
+      "message": "Ls2"
     },
     {
       "key": "ChatType.Ls3",
-      "message": "Ls3",
-      "description": ""
+      "message": "Ls3"
     },
     {
       "key": "ChatType.Ls4",
-      "message": "Ls4",
-      "description": ""
+      "message": "Ls4"
     },
     {
       "key": "ChatType.Ls5",
-      "message": "Ls5",
-      "description": ""
+      "message": "Ls5"
     },
     {
       "key": "ChatType.Ls6",
-      "message": "Ls6",
-      "description": ""
+      "message": "Ls6"
     },
     {
       "key": "ChatType.Ls7",
-      "message": "Ls7",
-      "description": ""
+      "message": "Ls7"
     },
     {
       "key": "ChatType.Ls8",
-      "message": "Ls8",
-      "description": ""
+      "message": "Ls8"
     },
     {
       "key": "ChatType.Ls1.Help",
-      "message": "When checked /linkshell1 (/ls1) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell1 (/ls1) messages are included."
     },
     {
       "key": "ChatType.Ls2.Help",
-      "message": "When checked /linkshell2 (/ls2) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell2 (/ls2) messages are included."
     },
     {
       "key": "ChatType.Ls3.Help",
-      "message": "When checked /linkshell3 (/ls3) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell3 (/ls3) messages are included."
     },
     {
       "key": "ChatType.Ls4.Help",
-      "message": "When checked /linkshell4 (/ls4) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell4 (/ls4) messages are included."
     },
     {
       "key": "ChatType.Ls5.Help",
-      "message": "When checked /linkshell5 (/ls5) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell5 (/ls5) messages are included."
     },
     {
       "key": "ChatType.Ls6.Help",
-      "message": "When checked /linkshell6 (/ls6) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell6 (/ls6) messages are included."
     },
     {
       "key": "ChatType.Ls7.Help",
-      "message": "When checked /linkshell7 (/ls7) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell7 (/ls7) messages are included."
     },
     {
       "key": "ChatType.Ls8.Help",
-      "message": "When checked /linkshell8 (/ls8) messages are included.",
-      "description": ""
+      "message": "When checked /linkshell8 (/ls8) messages are included."
     },
     {
       "key": "ChatType.Cwls1",
-      "message": "Cwls1",
-      "description": ""
+      "message": "Cwls1"
     },
     {
       "key": "ChatType.Cwls2",
-      "message": "Cwls2",
-      "description": ""
+      "message": "Cwls2"
     },
     {
       "key": "ChatType.Cwls3",
-      "message": "Cwls3",
-      "description": ""
+      "message": "Cwls3"
     },
     {
       "key": "ChatType.Cwls4",
-      "message": "Cwls4",
-      "description": ""
+      "message": "Cwls4"
     },
     {
       "key": "ChatType.Cwls5",
-      "message": "Cwls5",
-      "description": ""
+      "message": "Cwls5"
     },
     {
       "key": "ChatType.Cwls6",
-      "message": "Cwls6",
-      "description": ""
+      "message": "Cwls6"
     },
     {
       "key": "ChatType.Cwls7",
-      "message": "Cwls7",
-      "description": ""
+      "message": "Cwls7"
     },
     {
       "key": "ChatType.Cwls8",
-      "message": "Cwls8",
-      "description": ""
+      "message": "Cwls8"
     },
     {
       "key": "ChatType.Cwls1.Help",
-      "message": "When checked /cwlinkshell1 (/cwl1) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell1 (/cwl1) messages are included."
     },
     {
       "key": "ChatType.Cwls2.Help",
-      "message": "When checked /cwlinkshell2 (/cwl2) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell2 (/cwl2) messages are included."
     },
     {
       "key": "ChatType.Cwls3.Help",
-      "message": "When checked /cwlinkshell3 (/cwl3) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell3 (/cwl3) messages are included."
     },
     {
       "key": "ChatType.Cwls4.Help",
-      "message": "When checked /cwlinkshell4 (/cwl4) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell4 (/cwl4) messages are included."
     },
     {
       "key": "ChatType.Cwls5.Help",
-      "message": "When checked /cwlinkshell5 (/cwl5) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell5 (/cwl5) messages are included."
     },
     {
       "key": "ChatType.Cwls6.Help",
-      "message": "When checked /cwlinkshell6 (/cwl6) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell6 (/cwl6) messages are included."
     },
     {
       "key": "ChatType.Cwls7.Help",
-      "message": "When checked /cwlinkshell7 (/cwl7) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell7 (/cwl7) messages are included."
     },
     {
       "key": "ChatType.Cwls8.Help",
-      "message": "When checked /cwlinkshell8 (/cwl8) messages are included.",
-      "description": ""
+      "message": "When checked /cwlinkshell8 (/cwl8) messages are included."
     },
     {
       "key": "ChatType.Urgent.Help",
-      "message": "When checked include urgent messages sent by Square Enix.",
-      "description": ""
+      "message": "When checked include urgent messages sent by Square Enix."
     },
     {
       "key": "ChatType.Notice.Help",
-      "message": "When checked include notices sent by Square Enix.",
-      "description": ""
+      "message": "When checked include notices sent by Square Enix."
     },
     {
       "key": "ChatType.NoviceNetwork.Help",
-      "message": "When checked include novice network messages.",
-      "description": ""
+      "message": "When checked include novice network messages."
     },
     {
       "key": "ChatType.PvPTeam.Help",
-      "message": "When checked include PVP team messages.",
-      "description": ""
+      "message": "When checked include PVP team messages."
     },
     {
       "key": "ChatType.Echo.Help",
-      "message": "When checked include /echo messages.",
-      "description": ""
+      "message": "When checked include /echo messages."
     },
     {
       "key": "ChatType.SystemError.Help",
-      "message": "When checked include system error messages sent by Square Enix.",
-      "description": ""
+      "message": "When checked include system error messages sent by Square Enix."
     },
     {
       "key": "ChatType.SystemMessage.Help",
-      "message": "When checked include system messages sent by Square Enix.",
-      "description": ""
+      "message": "When checked include system messages sent by Square Enix."
     },
     {
       "key": "ChatType.Urgent",
-      "message": "Urgent",
-      "description": ""
+      "message": "Urgent"
     },
     {
       "key": "ChatType.Notice",
-      "message": "Notice",
-      "description": ""
+      "message": "Notice"
     },
     {
       "key": "ChatType.NoviceNetwork",
-      "message": "Novice",
-      "description": ""
+      "message": "Novice"
     },
     {
       "key": "ChatType.PvPTeam",
-      "message": "Pvp",
-      "description": ""
+      "message": "Pvp"
     },
     {
       "key": "ChatType.Echo",
-      "message": "Echo",
-      "description": ""
+      "message": "Echo"
     },
     {
       "key": "ChatType.SystemError",
-      "message": "Sys Error",
-      "description": ""
+      "message": "Sys Error"
     },
     {
       "key": "ChatType.SystemMessage",
-      "message": "Sys Message",
-      "description": ""
+      "message": "Sys Message"
     },
     {
       "key": "Tab.General",
-      "message": "General",
-      "description": ""
+      "message": "General"
     },
     {
       "key": "Tab.Groups",
-      "message": "Groups",
-      "description": ""
+      "message": "Groups"
     },
     {
       "key": "Label.FileNamePrefix",
-      "message": "File name prefix",
-      "description": ""
+      "message": "File name prefix"
     },
     {
       "key": "Label.FileNamePrefix.Help",
-      "message": "The prefix for all log files created by Chatter.",
-      "description": ""
+      "message": "The prefix for all log files created by Chatter."
     },
     {
       "key": "Label.SaveDirectory",
-      "message": "Save directory",
-      "description": ""
+      "message": "Save directory"
     },
     {
       "key": "Label.SaveDirectory.Help",
-      "message": "The directory where all logs are written. If the final part of the directory does not exist it will be created.",
-      "description": ""
+      "message": "The directory where all logs are written. If the final part of the directory does not exist it will be created."
     },
     {
       "key": "Button.Save",
-      "message": "Save",
-      "description": ""
+      "message": "Save"
     },
     {
       "key": "Label.IsActive.Checkbox",
-      "message": "Is active",
-      "description": ""
+      "message": "Is active"
     },
     {
       "key": "Label.IsActive.Checkbox.Help",
-      "message": "When checked messages that match this group will be written to its log file. Uncheck to stop writing out this log. The all log cannot be disabled. Cannot be changed for the all group.",
-      "description": ""
+      "message": "When checked messages that match this group will be written to its log file. Uncheck to stop writing out this log. The all log cannot be disabled."
     },
     {
       "key": "Label.IncludeAllUsers.Checkbox",
-      "message": "Include all users",
-      "description": ""
+      "message": "Include all users"
     },
     {
       "key": "Label.IncludeAllUsers.Checkbox.Help",
-      "message": "When checked all users will be included in this log even if they are not in the user list. When unchecked, only users in the user list will be included in the log. Cannot be changed for the all group.",
-      "description": ""
+      "message": "When checked all users will be included in this log even if they are not in the user list. When unchecked, only users in the user list will be included in the log. Cannot be changed for the all group."
     },
     {
       "key": "Label.IncludeServerName.Checkbox",
-      "message": "Include server name",
-      "description": ""
+      "message": "Include server name"
     },
     {
       "key": "Label.IncludeServerName.Checkbox.Help",
-      "message": "When checked the server names will be appended to each player's name. When unchecked server names will be removed from all names. Note: Adding server names to player names in messages may not work reliably for players on the same server as you.",
-      "description": ""
+      "message": "When checked the server names will be appended to each player's name. When unchecked server names will be removed from all names. Note: Adding server names to player names in messages may not work reliably for players on the same server as you."
     },
     {
       "key": "Label.IncludeSelf.Checkbox",
-      "message": "Include me",
-      "description": ""
+      "message": "Include me"
     },
     {
       "key": "Label.IncludeSelf.Checkbox.Help",
-      "message": "When checked you will be included in this log even if you are not in the user list. When unchecked, you will only be included in the log if you are included in the user list.",
-      "description": ""
+      "message": "When checked you will be included in this log even if you are not in the user list. When unchecked, you will only be included in the log if you are included in the user list."
     },
     {
       "key": "Label.IncludeAll.Checkbox",
-      "message": "Include all messages (debug)",
-      "description": ""
+      "message": "Include all messages (debug)"
     },
     {
       "key": "Label.IncludeAll.Checkbox.Help",
-      "message": "When checked all messages are included in this log, even ones that are normally ignored. This is only for debugging.",
-      "description": ""
+      "message": "When checked all messages are included in this log, even ones that are normally ignored. This is only for debugging."
     },
     {
       "key": "Header.IncludedUsers",
-      "message": "Included Users",
-      "description": ""
+      "message": "Included Users"
     },
     {
       "key": "Description.IncludedUsers",
-      "message": "These are the users that will be included in this log. You can also enter what you want each user to be renamed to in the log. This is generally used to shorten names to make the log easier to read.",
-      "description": ""
+      "message": "These are the users that will be included in this log. You can also enter what you want each user to be renamed to in the log. This is generally used to shorten names to make the log easier to read."
     },
     {
       "key": "Button.AddUser",
-      "message": "Add user",
-      "description": ""
+      "message": "Add user"
     },
     {
       "key": "Title.AddUser",
-      "message": "Add user",
-      "description": ""
+      "message": "Add user"
     },
     {
       "key": "ColumnHeader.FullName",
-      "message": "Player full name",
-      "description": ""
+      "message": "Player full name"
     },
     {
       "key": "ColumnHeader.Replacement",
-      "message": "Replace with",
-      "description": ""
+      "message": "Replace with"
     },
     {
       "key": "Header.IncludedChatTypes",
-      "message": "Included Chat Types",
-      "description": ""
+      "message": "Included Chat Types"
     },
     {
       "key": "Message.PlayerAlreadyInList",
-      "message": "That player is already in the list.",
-      "description": ""
+      "message": "That player is already in the list."
     },
     {
       "key": "Label.PlayerFullName",
-      "message": "Player full name",
-      "description": ""
+      "message": "Player full name"
     },
     {
       "key": "Label.PlayerFullName.Help",
-      "message": "The full name of the player including the player's home world separated by an at (@) sign e.g. Lord Farquod@Duloc. If a world is not present it will default to your home world. You can also use the Friend selector button to pick a player from your friend list.",
-      "description": ""
+      "message": "The full name of the player including the player's home world separated by an at (@) sign e.g. Lord Farquod@Duloc. If a world is not present it will default to your home world. You can also use the Friend selector button to pick a player from your friend list."
     },
     {
       "key": "Label.PlayerReplacement",
-      "message": "Player replacement name",
-      "description": ""
+      "message": "Player replacement name"
     },
     {
       "key": "Label.PlayerReplacement.Help",
-      "message": "If present, this is the name that will replace the full play name in the log, typically used to simplify names of players that are well-known to you.",
-      "description": ""
+      "message": "If present, this is the name that will replace the full play name in the log, typically used to simplify names of players that are well-known to you."
     },
     {
       "key": "Button.Add",
-      "message": "Add",
-      "description": ""
+      "message": "Add"
     },
     {
       "key": "Button.Remove",
-      "message": "Remove",
-      "description": ""
+      "message": "Remove"
     },
     {
       "key": "Button.Cancel",
-      "message": "Cancel",
-      "description": ""
+      "message": "Cancel"
     },
     {
       "key": "Button.ClearFilter.Help",
-      "message": "Clears the filter.",
-      "description": ""
+      "message": "Clears the filter."
     },
     {
       "key": "Button.FriendSelector.Help",
-      "message": "Brings up the Friend selector.",
-      "description": ""
+      "message": "Brings up the Friend selector."
     },
     {
       "key": "Text.RemoveUser",
-      "message": "Do you want to remove {0} from this log?",
-      "description": ""
+      "message": "Do you want to remove {0} from this log?"
     },
     {
       "key": "Combo.Order.GroupDate",
-      "message": "Group then date",
-      "description": ""
+      "message": "Group then date"
     },
     {
       "key": "Combo.Order.GroupDate.Help",
-      "message": "The log file names will be in the format: ''prefix-groupname-20230414-123456.log''. The operating system will sort the group file together.",
-      "description": ""
+      "message": "The log file names will be in the format: ''prefix-groupname-20230414-123456.log''. The operating system will sort the group file together."
     },
     {
       "key": "Combo.Order.DateGroup",
-      "message": "Date then group",
-      "description": ""
+      "message": "Date then group"
     },
     {
       "key": "Combo.Order.DateGroup.Help",
-      "message": "The log file names will be in the format: ''prefix-20230414-123456-groupname.log''. The operating system will sort the logs from the same time together.",
-      "description": ""
+      "message": "The log file names will be in the format: ''prefix-20230414-123456-groupname.log''. The operating system will sort the logs from the same time together."
     },
     {
       "key": "Combo.Timestamp.Cultural",
-      "message": "Cultural",
-      "description": ""
+      "message": "Cultural"
     },
     {
       "key": "Combo.Timestamp.Sortable",
-      "message": "Sortable",
-      "description": ""
+      "message": "Sortable"
     },
     {
       "key": "Combo.Timestamp.Cultural.Help",
-      "message": "Formats the timestamp in a way that is reasonable for the region you are in. This uses the default region settings of this computer. For example, this will look like: '5/4/2023 9:37:54 PM' in the US and '4/5/2023 21:37:54' in The Netherlands.'",
-      "description": ""
+      "message": "Formats the timestamp in a way that is reasonable for the region you are in. This uses the default region settings of this computer. For example, this will look like: '5/4/2023 9:37:54 PM' in the US and '4/5/2023 21:37:54' in The Netherlands.'"
     },
     {
       "key": "Combo.Timestamp.Sortable.Help",
-      "message": "Formats the timestamp in a way that allows for easy sorting, and is consistent across regions. It will still use this computer's time zone to format the timestamp. Timestamps will look like: 2023-05-04 16:25:38",
-      "description": ""
+      "message": "Formats the timestamp in a way that allows for easy sorting, and is consistent across regions. It will still use this computer's time zone to format the timestamp. Timestamps will look like: 2023-05-04 16:25:38"
     },
     {
       "key": "Combo.Order.Label",
-      "message": "Log file order",
-      "description": ""
+      "message": "Log file order"
     },
     {
       "key": "Combo.Order.Help",
-      "message": "Specifies the order of the parts of the log file name.",
-      "description": ""
+      "message": "Specifies the order of the parts of the log file name."
     },
     {
       "key": "Combo.Timestamp.Label",
-      "message": "Time format",
-      "description": ""
+      "message": "Time format"
     },
     {
       "key": "Combo.Timestamp.Help",
-      "message": "Which format to use for timestamps.",
-      "description": ""
+      "message": "Which format to use for timestamps."
     },
     {
       "key": "Input.WrapWidth.Label",
-      "message": "Wrap Width (chars)",
-      "description": ""
+      "message": "Wrap Width (chars)"
     },
     {
       "key": "Input.WrapWidth.Help",
-      "message": "The maximum width of each line of the message in characters. Lines longer than this will be broken into multiple lines. Set to 0 to not wrap.",
-      "description": ""
+      "message": "The maximum width of each line of the message in characters. Lines longer than this will be broken into multiple lines. Set to 0 to not wrap."
     },
     {
       "key": "Input.WrapIndent.Label",
-      "message": "Wrap Indent (chars)",
-      "description": ""
+      "message": "Wrap Indent (chars)"
     },
     {
       "key": "Input.WrapIndent.Help",
-      "message": "The indentation for each wrapped message line in characters. Set to 0 to have no indentation. Set to -1 to have the indentation calculated.",
-      "description": ""
+      "message": "The indentation for each wrapped message line in characters. Set to 0 to have no indentation. Set to -1 to have the indentation calculated."
     },
     {
       "key": "Button.AddGroup",
-      "message": "New group",
-      "description": ""
+      "message": "New group"
     },
     {
       "key": "Message.GroupAlreadyInList",
-      "message": "That group is already in the group list.",
-      "description": ""
+      "message": "That group is already in the group list."
     },
     {
       "key": "Label.GroupName",
-      "message": "Group name",
-      "description": ""
+      "message": "Group name"
     },
     {
       "key": "Label.GroupName.Help",
-      "message": "The name of the group. This will be used as part of the log file name, so it should be short, but understandable.",
-      "description": ""
+      "message": "The name of the group. This will be used as part of the log file name, so it should be short, but understandable. Names are restricted to Letters, Numbers, and the characters: -,=~!@#+"
     },
     {
       "key": "Button.Create",
-      "message": "Create",
-      "description": ""
+      "message": "Create"
     },
     {
       "key": "Label.Delete.Group",
-      "message": "Do you want to delete group {0}?",
-      "description": ""
+      "message": "Do you want to delete group {0}?"
     },
     {
       "key": "Title.Delete",
-      "message": "Delete?",
-      "description": ""
+      "message": "Delete?"
     },
     {
       "key": "Title.Remove",
-      "message": "Remove?",
-      "description": ""
+      "message": "Remove?"
     },
     {
       "key": "Combo.Directory.Unified",
-      "message": "Unified",
-      "description": ""
+      "message": "Unified"
     },
     {
       "key": "Combo.Directory.Unified.Help",
-      "message": "All log files will be placed in same directory.",
-      "description": ""
+      "message": "All log files will be placed in same directory."
     },
     {
       "key": "Combo.Directory.Group",
-      "message": "Group",
-      "description": ""
+      "message": "Group"
     },
     {
       "key": "Combo.Directory.Group.Help",
-      "message": "All log files for a group will be placed in same directory named for the group.",
-      "description": ""
+      "message": "All log files for a group will be placed in same directory named for the group."
     },
     {
       "key": "Combo.Directory.YearMonth",
-      "message": "Year/Month",
-      "description": ""
+      "message": "Year/Month"
     },
     {
       "key": "Combo.Directory.YearMonth.Help",
-      "message": "Log files will be placed in subdirectories named for the year, and then the month e.g. 2024/07.",
-      "description": ""
+      "message": "Log files will be placed in subdirectories named for the year, and then the month e.g. 2024/07."
     },
     {
       "key": "Combo.Directory.YearMonthGroup",
-      "message": "Year/Month/Group",
-      "description": ""
+      "message": "Year/Month/Group"
     },
     {
       "key": "Combo.Directory.YearMonthGroup.Help",
-      "message": "Log files will be placed in subdirectories named for the year, the month, and then the group e.g. 2024/07/all.",
-      "description": ""
+      "message": "Log files will be placed in subdirectories named for the year, the month, and then the group e.g. 2024/07/all."
     },
     {
       "key": "Combo.Directory.GroupYearMonth",
-      "message": "Group/Year/Month",
-      "description": ""
+      "message": "Group/Year/Month"
     },
     {
       "key": "Combo.Directory.GroupYearMonth.Help",
-      "message": "Log files will be placed in subdirectories named for the group, the year, and then the month e.g. all/2024/07.",
-      "description": ""
+      "message": "Log files will be placed in subdirectories named for the group, the year, and then the month e.g. all/2024/07."
     },
     {
       "key": "Combo.Directory.Label",
-      "message": "Log directory format",
-      "description": ""
+      "message": "Log directory format"
     },
     {
       "key": "Combo.Directory.Help",
-      "message": "Specifies the format for the log dirctory (nesting).",
-      "description": ""
+      "message": "Specifies the format for the log directory (nesting)."
     },
     {
       "key": "Button.Delete",
-      "message": "Delete",
-      "description": ""
+      "message": "Delete"
     },
     {
       "key": "Button.Restart",
-      "message": "Restart",
-      "description": ""
+      "message": "Restart"
     },
     {
       "key": "Button.Restart.Help",
-      "message": "Closes the current logs and reopens them using the updated configuration settings.",
-      "description": ""
+      "message": "Closes the current logs and reopens them using the updated configuration settings."
     },
     {
       "key": "Label.IsEvent.Checkbox",
-      "message": "Is event",
-      "description": ""
+      "message": "Is event"
     },
     {
       "key": "Label.IsEvent.Checkbox.Help",
-      "message": "Marks this as an event, which must be actively started and will only be active for a set period of time.",
-      "description": ""
+      "message": "Marks this as an event, which must be actively started and will only be active for a set period of time."
     },
     {
       "key": "Message.EventAlreadyInList",
-      "message": "Event and group names must be unique.",
-      "description": ""
+      "message": "Event and group names must be unique."
     },
     {
       "key": "Label.EventName",
-      "message": "Event name",
-      "description": ""
+      "message": "Event name"
     },
     {
       "key": "Label.EventName.Help",
-      "message": "The name of the event. This will be used as part of the log file name, so it should be short, but understandable.",
-      "description": ""
+      "message": "The name of the event. This will be used as part of the log file name, so it should be short, but understandable. Names are restricted to Letters, Numbers, and the characters: -,=~!@#"
     },
     {
       "key": "Button.AddEvent",
-      "message": "New event",
-      "description": ""
+      "message": "New event"
     },
     {
       "key": "Button.StartEvent",
-      "message": "Start event",
-      "description": ""
+      "message": "Start event"
     },
     {
       "key": "Button.StartEvent.Help",
-      "message": "Starts an inactive event.",
-      "description": ""
+      "message": "Starts an inactive event."
     },
     {
       "key": "Button.StopEvent",
-      "message": "Stop event",
-      "description": ""
+      "message": "Stop event"
     },
     {
       "key": "Button.StopEvent.Help",
-      "message": "Stops an active event.",
-      "description": ""
+      "message": "Stops an active event."
     },
     {
       "key": "Button.ShowConfig",
-      "message": "Show config",
-      "description": ""
+      "message": "Show config"
     },
     {
       "key": "Button.ShowConfig.Help",
-      "message": "Shows the config window.",
-      "description": ""
+      "message": "Shows the config window."
     },
     {
       "key": "Button.Start",
-      "message": "Start",
-      "description": ""
+      "message": "Start"
     },
     {
       "key": "Button.Stop",
-      "message": "Stop",
-      "description": ""
+      "message": "Stop"
     },
     {
       "key": "Label.ShowMinimalMain",
-      "message": "Show minimal main window",
-      "description": ""
+      "message": "Show minimal main window"
     },
     {
       "key": "Label.ShowMinimalMain.Help",
-      "message": "Shows the main Chatter window as small as possible to cover as little screen space as possible.",
-      "description": ""
+      "message": "Shows the main Chatter window as small as possible to cover as little screen space as possible."
     },
     {
       "key": "Combo.Period.Days",
-      "message": "Days",
-      "description": ""
+      "message": "Days"
     },
     {
       "key": "Combo.Period.Days.Help",
-      "message": "The number of days to run.",
-      "description": ""
+      "message": "The number of days to run."
     },
     {
       "key": "Combo.Period.Hours",
-      "message": "Hours",
-      "description": ""
+      "message": "Hours"
     },
     {
       "key": "Combo.Period.Hours.Help",
-      "message": "The number of hours to run.",
-      "description": ""
+      "message": "The number of hours to run."
     },
     {
       "key": "Combo.Period.Minutes",
-      "message": "Minutes",
-      "description": ""
+      "message": "Minutes"
     },
     {
       "key": "Combo.Period.Minutes.Help",
-      "message": "The number of minutes to run.",
-      "description": ""
+      "message": "The number of minutes to run."
     },
     {
       "key": "Label.Period",
-      "message": "Period",
-      "description": ""
+      "message": "Period"
     },
     {
       "key": "Label.Period.Help",
-      "message": "The length of the period.",
-      "description": ""
+      "message": "The length of the period."
     },
     {
       "key": "Label.EventLength",
-      "message": "Event length",
-      "description": ""
+      "message": "Event length"
     },
     {
       "key": "Label.EventLength.Help",
-      "message": "The legnth of time this event will be active.",
-      "description": ""
+      "message": "The length of time this event will be active."
     },
     {
       "key": "Title.StartEvent",
-      "message": "Start Event",
-      "description": ""
+      "message": "Start Event"
     },
     {
       "key": "Title.StopEvent",
-      "message": "Stop Event",
-      "description": ""
+      "message": "Stop Event"
     },
     {
       "key": "Combo.NoInactiveEvents",
-      "message": "(no inactive events)",
-      "description": ""
+      "message": "(no inactive events)"
     },
     {
       "key": "Combo.NoInactiveEvents.Help",
-      "message": "There are no inactive events to start.",
-      "description": ""
+      "message": "There are no inactive events to start."
     },
     {
       "key": "Label.EventsInactive",
-      "message": "Events",
-      "description": ""
+      "message": "Events"
     },
     {
       "key": "Label.EventsInactive.Help",
-      "message": "The list of inactive events to choose from.",
-      "description": ""
+      "message": "The list of inactive events to choose from."
     },
     {
       "key": "Combo.NoActiveEvents",
-      "message": "(no active events)",
-      "description": ""
+      "message": "(no active events)"
     },
     {
       "key": "Combo.NoActiveEvents.Help",
-      "message": "There are no active events to stop.",
-      "description": ""
+      "message": "There are no active events to stop."
     },
     {
       "key": "Label.EventsActive",
-      "message": "Events",
-      "description": ""
+      "message": "Events"
     },
     {
       "key": "Label.EventsActive.Help",
-      "message": "The list of active events to choose from.",
-      "description": ""
+      "message": "The list of active events to choose from."
     },
     {
       "key": "Title.MainWindow",
-      "message": "Chatter",
-      "description": ""
+      "message": "Chatter"
     },
     {
       "key": "Title.ConfigurationWindow",
-      "message": "Chatter Configuration",
-      "description": ""
-    },
-    {
-      "key": "Label.TimeRemaining",
-      "message": "Time remaining {0}",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Days",
-      "message": "1|Format.Period.Days.1,*|Format.Period.Days.0",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Days.0",
-      "message": "{0:D} days, {1:D} hours, {2:D} minutes, and {3:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Days.1",
-      "message": "{0:D} day, {1:D} hours, {2:D} minutes, and {3:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Hours",
-      "message": "1|Format.Period.Hours.1,*|Format.Period.Hours.0",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Hours.0",
-      "message": "{0:D} hours, {1:D} minutes, and {2:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Hours.1",
-      "message": "{0:D} hour, {1:D} minutes, and {2:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Minutes",
-      "message": "1|Format.Period.Minutes.1,*|Format.Period.Minutes.0",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Minutes.0",
-      "message": "{0:D} minutes and {1:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Minutes.1",
-      "message": "{0:D} minute and {1:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Seconds",
-      "message": "1|Format.Period.Seconds.1,*|Format.Period.Seconds.0",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Seconds.0",
-      "message": "{0:D} seconds",
-      "description": ""
-    },
-    {
-      "key": "Format.Period.Seconds.1",
-      "message": "{0:D} second",
-      "description": ""
-    },
-    {
-      "key": "Button.RemoveUser.Help",
-      "message": "Removes the user.",
-      "description": ""
-    },
-    {
-      "key": "Button.DeleteGroup.Help",
-      "message": "Deletes the group.",
-      "description": ""
+      "message": "Chatter Configuration"
     },
     {
       "key": "Button.CopyToClipboard.Help",
-      "message": "Copies the directory path to theclipboard and opens the file explorer at the location.",
-      "description": ""
+      "message": "Copies the directory path to the clipboard and opens the file explorer at the location."
+    },
+    {
+      "key": "Label.TimeRemaining",
+      "message": "Time remaining {0}"
+    },
+    {
+      "key": "Format.Period.Days",
+      "message": "1|Format.Period.Days.1,*|Format.Period.Days.0"
+    },
+    {
+      "key": "Format.Period.Days.0",
+      "message": "{0:D} days, {1:D} hours, {2:D} minutes, and {3:D} seconds"
+    },
+    {
+      "key": "Format.Period.Days.1",
+      "message": "{0:D} day, {1:D} hours, {2:D} minutes, and {3:D} seconds"
+    },
+    {
+      "key": "Format.Period.Hours",
+      "message": "1|Format.Period.Hours.1,*|Format.Period.Hours.0"
+    },
+    {
+      "key": "Format.Period.Hours.0",
+      "message": "{0:D} hours, {1:D} minutes, and {2:D} seconds"
+    },
+    {
+      "key": "Format.Period.Hours.1",
+      "message": "{0:D} hour, {1:D} minutes, and {2:D} seconds"
+    },
+    {
+      "key": "Format.Period.Minutes",
+      "message": "1|Format.Period.Minutes.1,*|Format.Period.Minutes.0"
+    },
+    {
+      "key": "Format.Period.Minutes.0",
+      "message": "{0:D} minutes and {1:D} seconds"
+    },
+    {
+      "key": "Format.Period.Minutes.1",
+      "message": "{0:D} minute and {1:D} seconds"
+    },
+    {
+      "key": "Format.Period.Seconds",
+      "message": "1|Format.Period.Seconds.1,*|Format.Period.Seconds.0"
+    },
+    {
+      "key": "Format.Period.Seconds.0",
+      "message": "{0:D} seconds"
+    },
+    {
+      "key": "Format.Period.Seconds.1",
+      "message": "{0:D} second"
+    },
+    {
+      "key": "Button.RemoveUser.Help",
+      "message": "Removes the user."
+    },
+    {
+      "key": "Button.DeleteGroup.Help",
+      "message": "Deletes the group."
     }
   ]
 }

--- a/Chatter/System/ILogger.cs
+++ b/Chatter/System/ILogger.cs
@@ -47,6 +47,13 @@ public interface ILogger
     /// <summary>
     ///     Sends the formatted string to the error log output.
     /// </summary>
+    /// <param name="pattern">The message patter string.</param>
+    /// <param name="args">Any replacement parameters for the pattern.</param>
+    void Error(string pattern, params object[] args);
+
+    /// <summary>
+    ///     Sends the formatted string to the error log output.
+    /// </summary>
     /// <param name="exception">The exception that caused the error.</param>
     /// <param name="pattern">The message patter string.</param>
     /// <param name="args">Any replacement parameters for the pattern.</param>

--- a/Chatter/System/Logger.cs
+++ b/Chatter/System/Logger.cs
@@ -41,6 +41,11 @@ public class Logger(IPluginLog pluginLog) : ILogger
         pluginLog.Debug(pattern, args);
     }
 
+    public void Error(string pattern, params object[] args)
+    {
+        pluginLog.Error(pattern, args);
+    }
+
     public void Error(Exception? exception, string pattern, params object[] args)
     {
         pluginLog.Error(exception, pattern, args);

--- a/Chatter/Windows/ConfigWindow.cs
+++ b/Chatter/Windows/ConfigWindow.cs
@@ -52,8 +52,6 @@ namespace Chatter.Windows;
 /// </summary>
 public sealed partial class ConfigWindow : Window
 {
-    private const string Title = "Chatter Configuration";
-
     /// <summary>
     ///     The list of chat types for the General section.
     /// </summary>
@@ -132,9 +130,9 @@ public sealed partial class ConfigWindow : Window
     private string _addEventName = Empty;
     private string _addUserFullName = Empty;
     private string _addUserReplacementName = Empty;
-    private IEnumerable<Friend> _filteredFriends = new List<Friend>();
+    private IEnumerable<Friend> _filteredFriends = [];
     private string _friendFilter = Empty;
-    private IEnumerable<Friend> _friends = new List<Friend>();
+    private IEnumerable<Friend> _friends = [];
     private int _directoryFormSelected = -1;
     private int _logOrderSelected = -1;
     private bool _removeDialogIsOpen = true;
@@ -162,7 +160,7 @@ public sealed partial class ConfigWindow : Window
                         FriendManager friendManager,
                         ChatLogManager chatLogManager,
                         ISharedImmediateTexture chatterImage,
-                        Loc loc) : base(Title)
+                        Loc loc) : base(loc.Message("Title.ConfigurationWindow"))
     {
         _configuration = config;
         _logger = logger;
@@ -393,7 +391,7 @@ public sealed partial class ConfigWindow : Window
                 var now = SystemClock.Instance.InBclSystemDefaultZone().GetCurrentLocalDateTime();
                 var diff = endTime - now;
                 var timeLeft = FormatPeriod(diff);
-                ImGui.TextUnformatted($"Time remaining {timeLeft}");
+                ImGui.TextUnformatted(Format(MsgLabelTimeRemaining, timeLeft));
             }
 
             ImGui.Spacing();
@@ -537,27 +535,20 @@ public sealed partial class ConfigWindow : Window
     {
         if (period.Days > 0)
         {
-            return Format("{0:D} days, {1:D} hours, {2:D} minutes, and {3:D} seconds",
-                          period.Days,
-                          period.Hours,
-                          period.Minutes,
-                          period.Seconds);
+            return MsgFormatPeriodDays.Format(period.Days, period.Hours, period.Minutes, period.Seconds);
         }
 
         if (period.Hours > 0)
         {
-            return Format("{0:D} hours, {1:D} minutes, and {2:D} seconds",
-                          period.Hours,
-                          period.Minutes,
-                          period.Seconds);
+            return MsgFormatPeriodHours.Format(period.Hours, period.Minutes, period.Seconds);
         }
 
         if (period.Minutes > 0)
         {
-            return Format("{0:D} minutes, and {1:D} seconds", period.Minutes, period.Seconds);
+            return MsgFormatPeriodMinutes.Format(period.Minutes, period.Seconds);
         }
 
-        return Format("{0:D} seconds", period.Seconds);
+        return MsgFormatPeriodSeconds.Format(period.Seconds);
     }
 
     /// <summary>
@@ -823,7 +814,7 @@ public sealed partial class ConfigWindow : Window
     /// <returns><c>true</c> if the button was pressed.</returns>
     private bool DrawRemoveButton(string id, bool disabled = false)
     {
-        return ImGuiWidgets.DrawIconButton($"Trash-{id}", FontAwesomeIcon.Trash, "Remove the user", disabled);
+        return ImGuiWidgets.DrawIconButton($"Trash-{id}", FontAwesomeIcon.Trash, MsgButtonRemoveUserHelp, disabled);
     }
 
     /// <summary>
@@ -834,7 +825,7 @@ public sealed partial class ConfigWindow : Window
     /// <returns><c>true</c> if the button was pressed.</returns>
     private bool DrawDeleteGroupButton(string id, bool disabled = false)
     {
-        return ImGuiWidgets.DrawIconButton($"Trash-{id}", FontAwesomeIcon.Trash, "Delete the group", disabled);
+        return ImGuiWidgets.DrawIconButton($"Trash-{id}", FontAwesomeIcon.Trash, MsgButtonDeleteGroupHelp, disabled);
     }
 
     /// <summary>
@@ -845,7 +836,7 @@ public sealed partial class ConfigWindow : Window
     /// <returns><c>true</c> if the button was pressed.</returns>
     private bool DrawCopyButton(string id, bool disabled = false)
     {
-        return ImGuiWidgets.DrawIconButton($"Copy-{id}", FontAwesomeIcon.Copy, "Copy to clipboard", disabled);
+        return ImGuiWidgets.DrawIconButton($"Copy-{id}", FontAwesomeIcon.Copy, MsgButtonCopyToClipboardHelp, disabled);
     }
 
     /// <summary>

--- a/Chatter/Windows/ConfigWindow.messages.cs
+++ b/Chatter/Windows/ConfigWindow.messages.cs
@@ -21,6 +21,8 @@
 // OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+using Chatter.Localization;
+
 namespace Chatter.Windows;
 
 /// <summary>
@@ -28,16 +30,23 @@ namespace Chatter.Windows;
 /// </summary>
 public partial class ConfigWindow
 {
+    private IPluralMessage MsgFormatPeriodDays => _loc.MessagePlural("Format.Period.Days");
+    private IPluralMessage MsgFormatPeriodHours => _loc.MessagePlural("Format.Period.Hours");
+    private IPluralMessage MsgFormatPeriodMinutes => _loc.MessagePlural("Format.Period.Minutes");
+    private IPluralMessage MsgFormatPeriodSeconds => _loc.MessagePlural("Format.Period.Seconds");
     private string MsgButtonAdd => _loc.Message("Button.Add");
     private string MsgButtonAddEvent => _loc.Message("Button.AddEvent");
     private string MsgButtonAddGroup => _loc.Message("Button.AddGroup");
     private string MsgButtonAddUser => _loc.Message("Button.AddUser");
     private string MsgButtonCancel => _loc.Message("Button.Cancel");
     private string MsgButtonClearFilterHelp => _loc.Message("Button.ClearFilter.Help");
+    private string MsgButtonCopyToClipboardHelp => _loc.Message("Button.CopyToClipboard.Help");
     private string MsgButtonCreate => _loc.Message("Button.Create");
     private string MsgButtonDelete => _loc.Message("Button.Delete");
+    private string MsgButtonDeleteGroupHelp => _loc.Message("Button.DeleteGroup.Help");
     private string MsgButtonFriendSelectorHelp => _loc.Message("Button.FriendSelector.Help");
     private string MsgButtonRemove => _loc.Message("Button.Remove");
+    private string MsgButtonRemoveUserHelp => _loc.Message("Button.RemoveUser.Help");
     private string MsgButtonRestart => _loc.Message("Button.Restart");
     private string MsgButtonRestartHelp => _loc.Message("Button.Restart.Help");
     private string MsgColumnFullName => _loc.Message("ColumnHeader.FullName");
@@ -98,14 +107,15 @@ public partial class ConfigWindow
     private string MsgLabelIsEventHelp => _loc.Message("Label.IsEvent.Checkbox.Help");
     private string MsgLabelSaveDirectory => _loc.Message("Label.SaveDirectory");
     private string MsgLabelSaveDirectoryHelp => _loc.Message("Label.SaveDirectory.Help");
-    private string MsgShowMinimalMain => _loc.Message("Label.ShowMinimalMain");
-    private string MsgShowMinimalMainHelp => _loc.Message("Label.ShowMinimalMain.Help");
+    private string MsgLabelTimeRemaining => _loc.Message("Label.TimeRemaining");
     private string MsgPlayerAlreadyInList => _loc.Message("Message.PlayerAlreadyInList");
     private string MsgPlayerFullName => _loc.Message("Label.PlayerFullName");
     private string MsgPlayerFullNameHelp => _loc.Message("Label.PlayerFullName.Help");
     private string MsgPlayerReplacement => _loc.Message("Label.PlayerReplacement");
     private string MsgPlayerReplacementHelp => _loc.Message("Label.PlayerReplacement.Help");
     private string MsgRemoveUser => _loc.Message("Text.RemoveUser");
+    private string MsgShowMinimalMain => _loc.Message("Label.ShowMinimalMain");
+    private string MsgShowMinimalMainHelp => _loc.Message("Label.ShowMinimalMain.Help");
     private string MsgTabGeneral => _loc.Message("Tab.General");
     private string MsgTabGroups => _loc.Message("Tab.Groups");
     private string MsgTitleDelete => _loc.Message("Title.Delete");

--- a/Chatter/Windows/JlkWindowManager.cs
+++ b/Chatter/Windows/JlkWindowManager.cs
@@ -43,7 +43,7 @@ public sealed class JlkWindowManager : IDisposable
     private readonly ConfigWindow _configWindow;
     private readonly IDalamudPluginInterface _pluginInterface;
     private readonly WindowSystem _windowSystem;
-    private readonly SelectEventPopup _selectEventPopup;
+    private readonly StartEventPopup _startEventPopup;
     private readonly StopEventPopup _stopEventPopup;
 
     /// <summary>
@@ -73,7 +73,7 @@ public sealed class JlkWindowManager : IDisposable
         _mainWindow = Add(new MainWindow(this, config, chatLogManager, loc));
         _configWindow =
             Add(new ConfigWindow(config, logger, dateHelper, friendManager, chatLogManager, chatterImage, loc));
-        _selectEventPopup = Add(new SelectEventPopup(this, config, loc));
+        _startEventPopup = Add(new StartEventPopup(this, config, loc));
         _stopEventPopup = Add(new StopEventPopup(this, config, loc));
         _pluginInterface.UiBuilder.Draw += _windowSystem.Draw;
         _pluginInterface.UiBuilder.OpenMainUi += ToggleMain;
@@ -116,29 +116,29 @@ public sealed class JlkWindowManager : IDisposable
     }
 
     /// <summary>
-    ///     Shows the select event popup.
+    ///     Shows the start event popup.
     /// </summary>
-    public void ShowSelectEvent(Vector2? position = null)
+    public void ShowStartEvent(Vector2? position = null)
     {
         if (position == null)
         {
-            _selectEventPopup.PositionCondition = ImGuiCond.None;
+            _startEventPopup.PositionCondition = ImGuiCond.None;
         }
         else
         {
-            _selectEventPopup.PositionCondition = ImGuiCond.Appearing;
-            _selectEventPopup.Position = position;
+            _startEventPopup.PositionCondition = ImGuiCond.Appearing;
+            _startEventPopup.Position = position;
         }
 
-        _selectEventPopup.IsOpen = true;
+        _startEventPopup.IsOpen = true;
     }
 
     /// <summary>
-    ///     Shows the select event popup.
+    ///     Hides the start event popup.
     /// </summary>
-    public void HideSelectEvent()
+    public void HideStartEvent()
     {
-        _selectEventPopup.IsOpen = false;
+        _startEventPopup.IsOpen = false;
     }
 
     /// <summary>

--- a/Chatter/Windows/MainWindow.cs
+++ b/Chatter/Windows/MainWindow.cs
@@ -38,8 +38,6 @@ namespace Chatter.Windows;
 /// </summary>
 public sealed partial class MainWindow : Window
 {
-    private const string Title = "Chatter";
-
     private readonly JlkWindowManager _windowManager;
     private readonly Configuration _config;
     private readonly ChatLogManager _chatLogManager;
@@ -54,7 +52,7 @@ public sealed partial class MainWindow : Window
     /// <param name="chatLogManager"></param>
     /// <param name="loc"></param>
     public MainWindow(JlkWindowManager windowManager, Configuration config, ChatLogManager chatLogManager, Loc loc) :
-        base(Title, ImGuiWindowFlags.AlwaysAutoResize)
+        base(loc.Message("Title.MainWindow"), ImGuiWindowFlags.AlwaysAutoResize)
     {
         _windowManager = windowManager;
         _config = config;
@@ -118,7 +116,7 @@ public sealed partial class MainWindow : Window
     private void DrawStartEvent()
     {
         var loc = ImGui.GetCursorScreenPos();
-        if (DrawStartEventButton()) _windowManager.ShowSelectEvent(loc);
+        if (DrawStartEventButton()) _windowManager.ShowStartEvent(loc);
     }
 
     /// <summary>

--- a/Chatter/Windows/StartEventPopup.cs
+++ b/Chatter/Windows/StartEventPopup.cs
@@ -28,6 +28,7 @@ using ImGuiNET;
 using System.Linq;
 using System.Numerics;
 using Chatter.ImGuiX;
+using Dalamud.Interface.Utility.Raii;
 using NodaTime;
 using NodaTime.Extensions;
 
@@ -121,7 +122,7 @@ public sealed class StartEventPopup : Window
         ImGui.Separator();
         ImGuiWidgets.VerticalSpace();
 
-        using (ImGuiWith.Disabled(!_hasEvents))
+        using (ImRaii.Disabled(!_hasEvents))
         {
             if (ImGui.Button(MsgButtonStart, new Vector2(120, 0)))
             {

--- a/Chatter/Windows/StartEventPopup.cs
+++ b/Chatter/Windows/StartEventPopup.cs
@@ -38,9 +38,14 @@ namespace Chatter.Windows;
 /// <summary>
 ///     Defines the configuration editing window.
 /// </summary>
-public sealed class SelectEventPopup : Window
+public sealed class StartEventPopup : Window
 {
-    private const string Title = "Select Event";
+    private string MsgButtonStart => _loc.Message("Button.Start");
+    private string MsgButtonCancel => _loc.Message("Button.Cancel");
+    private string MsgNoInactiveEvents => _loc.Message("Combo.NoInactiveEvents");
+    private string MsgNoInactiveEventsHelp => _loc.Message("Combo.NoInactiveEvents.Help");
+    private string MsgEventsInactive => _loc.Message("Label.EventsInactive");
+    private string MsgEventsInactiveHelp => _loc.Message("Label.EventsInactive.Help");
 
     private readonly JlkWindowManager _windowManager;
     private readonly Configuration _configuration;
@@ -58,8 +63,8 @@ public sealed class SelectEventPopup : Window
     /// <param name="windowManager">The window manager.</param>
     /// <param name="config">The plugin configuration.</param>
     /// <param name="loc">The message localization object.</param>
-    public SelectEventPopup(JlkWindowManager windowManager, Configuration config, Loc loc) : base(Title,
-        ImGuiWindowFlags.AlwaysAutoResize)
+    public StartEventPopup(JlkWindowManager windowManager, Configuration config, Loc loc) :
+        base(loc.Message("Title.StartEvent"), ImGuiWindowFlags.AlwaysAutoResize)
     {
         _windowManager = windowManager;
         _configuration = config;
@@ -95,12 +100,7 @@ public sealed class SelectEventPopup : Window
         }
         else
         {
-            _items =
-            [
-                new ImGuiWidgets.ComboOption<string>("(no inactive events)",
-                                                     "-null-",
-                                                     "There are no inactive events to start."),
-            ];
+            _items = [new ImGuiWidgets.ComboOption<string>(MsgNoInactiveEvents, "-null-", MsgNoInactiveEventsHelp),];
         }
     }
 
@@ -109,10 +109,10 @@ public sealed class SelectEventPopup : Window
     /// </summary>
     public override void Draw()
     {
-        ImGuiWidgets.DrawCombo("Events",
+        ImGuiWidgets.DrawCombo(MsgEventsInactive,
                                _items,
                                _eventSelected,
-                               "Events",
+                               MsgEventsInactiveHelp,
                                onSelect: (ind) => { _eventSelected = ind; });
 
         ImGuiWidgets.VerticalSpace();
@@ -129,7 +129,7 @@ public sealed class SelectEventPopup : Window
                 var log = _configuration.ChatLogs[name];
                 log.EventStartTime = SystemClock.Instance.InBclSystemDefaultZone().GetCurrentLocalDateTime();
                 log.IsActive = true;
-                _windowManager.HideSelectEvent();
+                _windowManager.HideStartEvent();
             }
         }
 
@@ -137,24 +137,31 @@ public sealed class SelectEventPopup : Window
         ImGui.SameLine();
         if (ImGui.Button(MsgButtonCancel, new Vector2(120, 0)))
         {
-            _windowManager.HideSelectEvent();
+            _windowManager.HideStartEvent();
         }
     }
 
+    /// <summary>
+    /// Returns the current event length from the selected event. If there is no matching event,
+    /// <c>Period.ZERO</c> is returned.
+    /// </summary>
+    /// <returns>The currently selected event's event length.</returns>
     private Period GetEventLength()
     {
         var name = _items[_eventSelected].Value;
-        var log = _configuration.ChatLogs[name];
-        return log.EventLength;
+        return _configuration.ChatLogs.TryGetValue(name, out var log) ? log.EventLength : Period.Zero;
     }
 
+    /// <summary>
+    ///     Sets the currently selected event's event length.
+    /// </summary>
+    /// <param name="period">The new event length for the event.</param>
     private void SetEventLength(Period period)
     {
         var name = _items[_eventSelected].Value;
-        var log = _configuration.ChatLogs[name];
-        log.EventLength = period;
+        if (_configuration.ChatLogs.TryGetValue(name, out var log))
+        {
+            log.EventLength = period;
+        }
     }
-
-    private string MsgButtonStart => _loc.Message("Button.Start");
-    private string MsgButtonCancel => _loc.Message("Button.Cancel");
 }

--- a/Chatter/Windows/StopEventPopup.cs
+++ b/Chatter/Windows/StopEventPopup.cs
@@ -38,7 +38,12 @@ namespace Chatter.Windows;
 /// </summary>
 public sealed class StopEventPopup : Window
 {
-    private const string Title = "Stop Event";
+    private string MsgButtonStop => _loc.Message("Button.Stop");
+    private string MsgButtonCancel => _loc.Message("Button.Cancel");
+    private string MsgNoActiveEvents => _loc.Message("Combo.NoActiveEvents");
+    private string MsgNoActiveEventsHelp => _loc.Message("Combo.NoActiveEvents.Help");
+    private string MsgEventsActive => _loc.Message("Label.EventsActive");
+    private string MsgEventsActiveHelp => _loc.Message("Label.EventsActive.Help");
 
     private readonly JlkWindowManager _windowManager;
     private readonly Configuration _configuration;
@@ -54,8 +59,8 @@ public sealed class StopEventPopup : Window
     /// <param name="windowManager">The window manager.</param>
     /// <param name="config">The plugin configuration.</param>
     /// <param name="loc">The message localization object.</param>
-    public StopEventPopup(JlkWindowManager windowManager, Configuration config, Loc loc) : base(Title,
-        ImGuiWindowFlags.AlwaysAutoResize)
+    public StopEventPopup(JlkWindowManager windowManager, Configuration config, Loc loc) :
+        base(loc.Message("Title.StopEvent"), ImGuiWindowFlags.AlwaysAutoResize)
     {
         _windowManager = windowManager;
         _configuration = config;
@@ -87,12 +92,7 @@ public sealed class StopEventPopup : Window
         _hasEvents = _items.Count > 0;
         if (!_hasEvents)
         {
-            _items =
-            [
-                new ImGuiWidgets.ComboOption<string>("(no active events)",
-                                                     "-null-",
-                                                     "There are no active events to start."),
-            ];
+            _items = [new ImGuiWidgets.ComboOption<string>(MsgNoActiveEvents, "-null-", MsgNoActiveEventsHelp),];
         }
     }
 
@@ -101,10 +101,10 @@ public sealed class StopEventPopup : Window
     /// </summary>
     public override void Draw()
     {
-        ImGuiWidgets.DrawCombo("Events",
+        ImGuiWidgets.DrawCombo(MsgEventsActive,
                                _items,
                                _eventSelected,
-                               "Events",
+                               MsgEventsActiveHelp,
                                onSelect: (ind) => { _eventSelected = ind; });
 
         ImGuiWidgets.VerticalSpace();
@@ -127,7 +127,4 @@ public sealed class StopEventPopup : Window
             _windowManager.HideStopEvent();
         }
     }
-
-    private string MsgButtonStop => _loc.Message("Button.Stop");
-    private string MsgButtonCancel => _loc.Message("Button.Cancel");
 }

--- a/Chatter/Windows/StopEventPopup.cs
+++ b/Chatter/Windows/StopEventPopup.cs
@@ -28,6 +28,7 @@ using ImGuiNET;
 using System.Linq;
 using System.Numerics;
 using Chatter.ImGuiX;
+using Dalamud.Interface.Utility.Raii;
 
 // ReSharper disable InvertIf
 
@@ -109,7 +110,7 @@ public sealed class StopEventPopup : Window
 
         ImGuiWidgets.VerticalSpace();
 
-        using (ImGuiWith.Disabled(!_hasEvents))
+        using (ImRaii.Disabled(!_hasEvents))
         {
             if (ImGui.Button(MsgButtonStop, new Vector2(120, 0)))
             {


### PR DESCRIPTION
Added plural message handling and various cleanups.

Finally needed messages that varied based on a numeric value (e.g. 1 hour vs. 2 hours in English) so I added a simplified plural message handling. A message that support plurals is created with a special format in the message text that describes how to handle various replacement values such as "use this message for value 1" and "use this message for all remaining values".

Before I knew that ImRaii existed and what it was I created a similar albeit much simpler version. After finding out about it I decided to covert over to using it because it is "the way" and because their code handles more cases and is supported by Dalamud. A couple of cases that I use aren't yet supported so those remain.

As part of the plural message work I decided to simplify the message catalog format and remove the "description" field which wasn't really being used. Instead, I changed the parser to allow comments and if I decide to go back and add information for translation I will add them as comments.